### PR TITLE
Completely remove in-line self upgrade script for handling Ajax events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>co.cfly</groupId>
 	<artifactId>jsf-components</artifactId>
 	<packaging>jar</packaging>
-	<version>6.0.3-SNAPSHOT</version>
+	<version>6.0.4-SNAPSHOT</version>
 	<name>JSF Components</name>
 
 	<properties>

--- a/src/main/java/co/cfly/faces/renderers/ChoicesAutoCompleteRenderer.java
+++ b/src/main/java/co/cfly/faces/renderers/ChoicesAutoCompleteRenderer.java
@@ -45,7 +45,6 @@ public class ChoicesAutoCompleteRenderer extends RendererBase {
             writer.write((String) inputComponent.getAttributes().getOrDefault("placeholder", "Choose"));
             writer.endElement("option");
             writer.endElement("select");
-            writeScript(writer, inputComponent);
         }
         else {
             throw new RuntimeException("%s is not an instance of UIInput".formatted(component));
@@ -55,12 +54,5 @@ public class ChoicesAutoCompleteRenderer extends RendererBase {
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
         // NOOP
-    }
-
-    private void writeScript(ResponseWriter writer, UIComponent component) throws IOException {
-        writer.startElement("script", component);
-        writer.writeAttribute("type", "text/javascript", null);
-        writer.write("upgradeChoicesAutocompletes();");
-        writer.endElement("script");
     }
 }


### PR DESCRIPTION
Handling Ajax updates to re-initialize autocompletes is now entirely managed by usage of the __enqueueUpgrade and __dequeueUpgrade functions from core.js.