### PR TITLE
unhide dismiss button from acc. features, and give it a proper label

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>co.cfly</groupId>
 	<artifactId>jsf-components</artifactId>
 	<packaging>jar</packaging>
-	<version>6.0.4</version>
+	<version>6.0.6-SNAPSHOT</version>
 	<name>JSF Components</name>
 
 	<properties>

--- a/src/main/java/co/cfly/faces/components/ModalComponent.java
+++ b/src/main/java/co/cfly/faces/components/ModalComponent.java
@@ -70,7 +70,7 @@ public class ModalComponent extends ComponentBase {
             writer.writeAttribute("class", "btn-close", null);
             writer.writeAttribute("type", "button", null);
             writer.writeAttribute("data-bs-dismiss", "modal", null);
-            writer.writeAttribute("aria-hidden", "true", null);
+            writer.writeAttribute("aria-label", "Close", null);
             writer.endElement("button");
             writer.endElement("div");// End Modal Header Div
         }


### PR DESCRIPTION
Add an aria-label for modal dismiss button for use with accessibility tools.